### PR TITLE
Bump version to 0.3.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "0.3.0"
+version = "0.3.1"
 name = "ultraplonk-no-std"
 authors = ["Horizen Labs <admin@horizenlabs.io>"]
 repository = "https://github.com/zkVerify/ultraplonk_verifier"


### PR DESCRIPTION
After merging https://github.com/zkVerify/ultraplonk_verifier/pull/8, I wanted to move the tag `v0.3.0` there, but it appears that I don't have the permissions to do it. So I decided to publish a new `0.3.1` version and tag (which is also cleaner maybe)