### PR TITLE
Changed visibility for module utils to accommodate zkVerify

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub mod proof;
 mod srs;
 pub mod testhooks;
 mod types;
-mod utils;
+pub mod utils;
 
 use crate::{
     key::{read_g2, PreparedVerificationKey, VerificationKey},


### PR DESCRIPTION
This PR is necessary in order to be able to invoke `into_bytes` from zkVerify. This serialization is needed for computing a vk-hash that matches the one from Aztec.