### PR TITLE
Ignore unmaintained paste crate in cargo audit

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,5 +1,8 @@
 [advisories]
-ignore = []
+ignore = [
+        "RUSTSEC-2024-0436", # paste (transitive) is unmaintained because completed
+                             # It's fine to ignore it.
+]
 informational_warnings = ["unmaintained", "unsound"]
 
 [output]


### PR DESCRIPTION
Just ignore paste that's unmaintained. It's a transitive dependency. Interesting discussion about it https://users.rust-lang.org/t/paste-alternatives/126787